### PR TITLE
fix review dog error: reviewdog: failed to run 'git rev-parse --show-prefix': exit status 128

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 cd "$GITHUB_WORKSPACE/${INPUT_DIRECTORY}"
 
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 /usr/local/bin/phpcs.phar \


### PR DESCRIPTION
The github action starts failing with the following error
```
reviewdog: failed to run 'git rev-parse --show-prefix': exit status 128
reviewdog: failed to run 'git rev-parse --show-prefix': exit status 128
```
example: https://github.com/sdkawata/laravel-app-reviewdog-action-test/pull/1

git rev-parse fails with the following error
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

This is because, as of Git v2.35.2, git refuses to look .git directory
when its ownership differs from the current user.
cf. https://github.blog/2022-04-12-git-security-vulnerability-announced/#

To fix this, I add `safe.directory` configuration.

similar problem: https://github.com/reviewdog/action-stylelint/issues/78