### PR TITLE
fix: PHP 8.1 enum not recognized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-alpine
+FROM php:8.1-alpine
 
 ARG REVIEWDOG_VERSION=v0.10.0
 ARG PHPCS_VERSION=3.7.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM php:7.4-alpine
 
 ARG REVIEWDOG_VERSION=v0.10.0
-ARG PHPCS_VERSION=3.5.4
-ARG PHPMD_VERSION=2.8.2
+ARG PHPCS_VERSION=3.7.1
+ARG PHPMD_VERSION=2.13.0
 
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 RUN wget -P /usr/local/bin -q https://github.com/squizlabs/PHP_CodeSniffer/releases/download/${PHPCS_VERSION}/phpcs.phar \
-  && wget -P /usr/local/bin -q https://phpmd.org/static/${PHPMD_VERSION}/phpmd.phar \
+  && wget -P /usr/local/bin -q https://github.com/phpmd/phpmd/releases/download/${PHPMD_VERSION}/phpmd.phar \
   && chmod +x /usr/local/bin/phpcs.phar \
   && chmod +x /usr/local/bin/phpmd.phar
 


### PR DESCRIPTION
fix: PHP 8.1 enum not recognized

https://github.com/squizlabs/PHP_CodeSniffer/issues/3474